### PR TITLE
Implement review feature requiring login

### DIFF
--- a/app/Http/Controllers/Api/ReviewController.php
+++ b/app/Http/Controllers/Api/ReviewController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\ApiController;
+use App\Http\Requests\ReviewRequest;
+use App\Http\Resources\ReviewResource;
+use App\Models\Review;
+use Illuminate\Http\JsonResponse;
+
+class ReviewController extends ApiController
+{
+    public function __construct()
+    {
+        $this->middleware('auth:sanctum');
+    }
+
+    public function store(ReviewRequest $request): JsonResponse
+    {
+        $review = Review::create([
+            'user_id' => $request->user()->id,
+            'technician_id' => $request->technician_id,
+            'rating' => $request->rating,
+            'comment' => $request->comment,
+        ]);
+
+        return response()->json([
+            'message' => __('Review submitted successfully'),
+            'review' => new ReviewResource($review),
+        ]);
+    }
+}

--- a/app/Http/Requests/ReviewRequest.php
+++ b/app/Http/Requests/ReviewRequest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ReviewRequest extends FormRequest
+{
+    public function authorize()
+    {
+        return true;
+    }
+
+    public function rules()
+    {
+        return [
+            'technician_id' => 'required|exists:users,id',
+            'rating' => 'required|integer|min:1|max:5',
+            'comment' => 'required|string',
+        ];
+    }
+}

--- a/app/Http/Resources/ReviewResource.php
+++ b/app/Http/Resources/ReviewResource.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class ReviewResource extends JsonResource
+{
+    public function toArray($request)
+    {
+        return [
+            'id' => $this->id,
+            'rating' => $this->rating,
+            'comment' => $this->comment,
+            'technician_id' => $this->technician_id,
+            'user_id' => $this->user_id,
+            'created_at' => $this->created_at->format(config('app.app_date_format')),
+            'updated_at' => $this->updated_at->format(config('app.app_date_format')),
+        ];
+    }
+}

--- a/app/Models/Review.php
+++ b/app/Models/Review.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Review extends Model
+{
+    protected $fillable = [
+        'user_id',
+        'technician_id',
+        'rating',
+        'comment',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function technician(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'technician_id');
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,6 +23,7 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
             'remember_token' => Str::random(10),
+            'role_id' => 2,
         ];
     }
 

--- a/database/migrations/2025_06_19_122904_create_reviews_table.php
+++ b/database/migrations/2025_06_19_122904_create_reviews_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up()
+    {
+        Schema::create('reviews', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->onDelete('cascade');
+            $table->foreignId('technician_id')->constrained('users')->onDelete('cascade');
+            $table->tinyInteger('rating');
+            $table->text('comment');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('reviews');
+    }
+};

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -933,5 +933,6 @@
     "Your name": "Your name",
     "Your new password": "Your new password",
     "Your repair order": "Your repair order",
-    "Your repair status updated": "Your repair status updated"
+    "Your repair status updated": "Your repair status updated",
+    "Review submitted successfully": "Review submitted successfully"
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,6 +19,7 @@ use App\Http\Controllers\Api\QuickReplyController;
 use App\Http\Controllers\Api\RepairLogController;
 use App\Http\Controllers\Api\RepairOrderAxillaryController;
 use App\Http\Controllers\Api\RepairOrderController;
+use App\Http\Controllers\Api\ReviewController;
 use App\Http\Controllers\Api\RepairPriorityController;
 use App\Http\Controllers\Api\RepairStatusController;
 use App\Http\Controllers\Api\ReportController;
@@ -51,6 +52,7 @@ Route::group(['middleware' => 'isAjax', 'prefix' => config('app.version', 'codeh
     Route::get('print/{repairOrder}/repair/order', [PrintController::class, 'repair'])->name('repair-orders.print');
     Route::get('print/{repairOrder}/dispatch/info', [PrintController::class, 'dispatchInfo'])->name('repair-dispatch.print');
     Route::get('tax/implementation', [RepairOrderAxillaryController::class, 'getTax'])->name('repair.get.tax');
+    Route::middleware('auth:sanctum')->post('reviews', [ReviewController::class, 'store'])->name('reviews.store');
 
     Route::group(['prefix' => 'auth', 'namespace' => 'Auth'], function () {
         Route::post('login', [AuthController::class, 'login'])->name('auth.login');

--- a/tests/Feature/ReviewTest.php
+++ b/tests/Feature/ReviewTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Models\UserRole;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReviewTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function seedRoles(): void
+    {
+        UserRole::create(['name' => 'Admin', 'is_primary' => true, 'permissions' => []]);
+        UserRole::create(['name' => 'Technician', 'is_primary' => false, 'permissions' => []]);
+    }
+
+    public function test_guest_cannot_create_review(): void
+    {
+        $this->seedRoles();
+        $response = $this->postJson('/api/'.config('app.version','codehas').'/reviews', []);
+        $response->assertStatus(401);
+    }
+
+    public function test_authenticated_user_can_create_review(): void
+    {
+        $this->seedRoles();
+        $user = User::factory()->create();
+        $tech = User::factory()->create();
+
+        $response = $this->actingAs($user, 'sanctum')->postJson('/api/'.config('app.version','codehas').'/reviews', [
+            'technician_id' => $tech->id,
+            'rating' => 5,
+            'comment' => 'Great service',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('review.rating', 5);
+    }
+}


### PR DESCRIPTION
## Summary
- add `reviews` table and model
- create request, resource and controller for reviews
- expose `/reviews` API endpoint for authenticated users
- update language strings and user factory
- provide tests for new review API

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854016cef5083228712ae789fce6901