### PR TITLE
Fix Render deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Quick replies use to respond to customers while updating the repair log from the
 ## Бесплатный деплой на Render
 
 1. Зарегистрируйтесь на [Render](https://render.com/) и подключите к нему репозиторий.
-2. Создайте **Web Service** и выберите тариф `Free`.
+2. Создайте **Web Service** и выберите тариф `Free`. Важно выбрать окружение `PHP` ("Environment: PHP"), иначе Render может запустить приложение как Node.js и возникнет ошибка `Port scan timeout`. Можно воспользоваться опцией **Import from Blueprint**, чтобы параметры из `render.yaml` применились автоматически.
 3. В поле Build Command укажите:
 
 ```bash


### PR DESCRIPTION
## Summary
- clarify that the Render service must use the PHP environment
- mention Import from Blueprint to use `render.yaml`

## Testing
- `php -v` *(fails: command not found)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553dcd54648322a48d76de1781decd